### PR TITLE
Add mosquitto image tag

### DIFF
--- a/Infrastructure/mosquitto/build-dtc-mosquitto.ps1
+++ b/Infrastructure/mosquitto/build-dtc-mosquitto.ps1
@@ -1,1 +1,1 @@
-docker build -t dapr-trafficcontrol/mosquitto .
+docker build -t dapr-trafficcontrol/mosquitto:1.0 .

--- a/Infrastructure/mosquitto/build-dtc-mosquitto.sh
+++ b/Infrastructure/mosquitto/build-dtc-mosquitto.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker build -t dapr-trafficcontrol/mosquitto .
+docker build -t dapr-trafficcontrol/mosquitto:1.0 .

--- a/Infrastructure/mosquitto/start-mosquitto.ps1
+++ b/Infrastructure/mosquitto/start-mosquitto.ps1
@@ -1,1 +1,1 @@
-docker run -d -p 1883:1883 -p 9001:9001 --name dtc-mosquitto dapr-trafficcontrol/mosquitto
+docker run -d -p 1883:1883 -p 9001:9001 --name dtc-mosquitto dapr-trafficcontrol/mosquitto:1.0

--- a/Infrastructure/mosquitto/start-mosquitto.sh
+++ b/Infrastructure/mosquitto/start-mosquitto.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-docker run -d -p 1883:1883 -p 9001:9001 --name dtc-mosquitto dapr-trafficcontrol/mosquitto
+docker run -d -p 1883:1883 -p 9001:9001 --name dtc-mosquitto dapr-trafficcontrol/mosquitto:1.0


### PR DESCRIPTION
I've added a version number as image tag for the Mosquitto controller. This is also the case in the Dapr-TrafficControl sample app. The workshop instructions are also changed to reflect this change.