### PR TITLE
Update maildev version

### DIFF
--- a/Infrastructure/maildev/start-maildev.ps1
+++ b/Infrastructure/maildev/start-maildev.ps1
@@ -1,1 +1,1 @@
-docker run -d -p 4000:80 -p 4025:25 --name dtc-maildev maildev/maildev:latest
+docker run -d -p 4000:1080 -p 4025:1025 --name dtc-maildev maildev/maildev:2.0.5

--- a/Infrastructure/maildev/start-maildev.sh
+++ b/Infrastructure/maildev/start-maildev.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-docker run -d -p 4000:80 -p 4025:25 --name dtc-maildev maildev/maildev:latest
+docker run -d -p 4000:1080 -p 4025:1025 --name dtc-maildev maildev/maildev:2.0.5


### PR DESCRIPTION
There is a new version of the maildev SMTP server in which the issues with the HTML view are fixed. It is recommended to use this version. 
The description in the workshop has already been changed accordingly.